### PR TITLE
[CRM-8] Se agrega la clase web config

### DIFF
--- a/src/main/java/com/utp/sistema_comandas/config/WebConfig.java
+++ b/src/main/java/com/utp/sistema_comandas/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.utp.sistema_comandas.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+
+public class WebConfig implements WebMvcConfigurer{
+    
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:uploads/");
+
+        registry.addResourceHandler("/css/**")
+                .addResourceLocations("file:css/");
+        
+        registry.addResourceHandler("/js/**")
+                .addResourceLocations("file:js/");
+
+        registry.addResourceHandler("/image/**")
+                .addResourceLocations("file:image/");
+    }
+    
+}


### PR DESCRIPTION
Implementar la clase WebConfig para permitir que la aplicación Spring sirva archivos estáticos (como imágenes de productos subidas por usuarios, hojas de estilo CSS para la interfaz, scripts JavaScript para la interactividad, y otras imágenes) a través de URLs específicas.